### PR TITLE
Fixed a bug with wrong coordinates in the BOX function

### DIFF
--- a/CPCL2SVG.js
+++ b/CPCL2SVG.js
@@ -421,8 +421,8 @@ CPCL2SVG = {
 			var parameters = params.split(" ");
 
 			var x0 = parameters[0];
-			var y1 = parameters[1];
-			var x0 = parameters[2];
+			var y0 = parameters[1];
+			var x1 = parameters[2];
 			var y1 = parameters[3];
 			var width = parameters[4];
 


### PR DESCRIPTION
Seems like there was a typo in the variable names. The label (not in line) mode didn't work without this fix